### PR TITLE
fix: spicy sections missing function close

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -474,6 +474,7 @@ class MediaAffordancesElement extends HTMLElement {
             evt.preventDefault()
           }
         }
+      );
     }
 
     connectedCallback() {


### PR DESCRIPTION
This fixes an issue with the `SpicySections.js` that fails to close a function.