### PR TITLE
maintain aria-selected, not aria-expanded on tabs

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -227,13 +227,13 @@ class MediaAffordancesElement extends HTMLElement {
             let relatedContent = sibLabel.nextElementSibling;
             sibLabel.tabIndex = -1;
             relatedContent.style.display = "none";
-            sibLabel.setAttribute("aria-expanded", "false");
+            sibLabel.setAttribute("aria-selected", "false");
             sibLabel.affordanceState.exclusiveExpanded = false;
           });
           label.tabIndex = 0;
           label.parentElement.affordanceState.exclusiveSelection.index = index;
           label.nextElementSibling.style.display = "block";
-          label.setAttribute("aria-expanded", "true");
+          label.setAttribute("aria-selected", "true");
           label.affordanceState.exclusiveExpanded = true;
           label.focus();
         }


### PR DESCRIPTION
The code clears out attributes as afforances change and establishes/maintains the current set. It seems tabs was initially setting `aria-selected` (correct) but maintaining `aria-expanded`.  This should correct it.  

closes #12