### PR TITLE
Update SpicySections.js

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -460,6 +460,7 @@ class MediaAffordancesElement extends HTMLElement {
             } else if (evt.keyCode == 39 || evt.keyCode == 40) {
               labels[next].affordanceState.activate();
             }
+            evt.preventDefault()
           } else if (evt.keyCode == 32 && this.affordanceState.current === 'collapse') {
             evt.preventDefault()
           }


### PR DESCRIPTION
Make sure to prevent default on arrow keys to avoid scrolling the page.  Realistically this will probably be re-written as we clean things up, but for now I think this handles it.  Closes the issue no one opened but we all locally fixed and discussed.