### PR TITLE
Honour fragment link on nav and hashchange (fixes #3)

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -416,6 +416,28 @@ class MediaAffordancesElement extends HTMLElement {
       }
     };
 
+    honourFragmentLink = () => {
+      let labels = getLabels(this);
+
+      if (location.hash && this.querySelector(location.hash)) {
+        // try to find a label with this ID, or controlled content
+        // that contains an element with this ID
+        for (let i = 0; i < labels.length; i++) {
+          let relevantContent =
+            labels[i].getAttribute("aria-controls") &&
+            this.querySelector(`#${labels[i].getAttribute("aria-controls")}`);
+
+          if (
+            labels[i] === this.querySelector(location.hash) ||
+            (relevantContent && relevantContent.querySelector(location.hash))
+          ) {
+            labels[i].affordanceState.activate();
+            return;
+          }
+        }
+      }
+    };
+
     /*
       Wires up suppored affordances...
     */
@@ -469,7 +491,13 @@ class MediaAffordancesElement extends HTMLElement {
     connectedCallback() {
       super.connectedCallback();
 
-      //TODO: check whether there is a hash/handle selection
+      //TODO: handle selection
+
+      if (location.hash) {
+        setTimeout(this.honourFragmentLink, 1);
+      }
+
+      window.addEventListener("hashchange", this.honourFragmentLink);
 
       // If you append a fragment with a pair, it should work
       this.__childListObserver.observe(this, { childList: true });


### PR DESCRIPTION
I've added some code that opens section content when page opens with hash or when the hash changes.

This works both if: 

- heading that is the `label` is the fragment
- content that 'belongs to' heading (eg tab panel, collapsible content) contains the fragment

Demo here: https://codepen.io/hidde/pen/RwZbgVK 

One weird thing: in Firefox, the location.hash change only works if wrapped in `setTimeout` (1 millisecond works 🤷🏻‍♂️); in Chromium this hack is not required.