### PR TITLE
Update tests to run headless and in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install modules
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A custom element that allows authors to employ tabs, accordions and summary+detail like UI affordances via CSS over otherwise good semantic content",
   "main": "index.js",
   "scripts": {
-    "test": "testcafe firefox test/general.tests.js -e"
+    "test": "testcafe \"firefox:headless\" test/general.tests.js -e"
   },
   "author": "Brian Kardell <bkardell@igalia.com>",
   "contributors": [


### PR DESCRIPTION
This PR updates the tests to run headless, and to run them from CI during pushes to the main branch.

Running the tests headless has allowed them to work on my own machine. Please checkout the branch to verify this works for you, as well.

Running the tests during CI allows the project to catch bugs on main. This is only a first step, and it can be improved later.

This PR needs to add the `.gitignore` file to prevent `node_modules` and `package-lock.json` from being automatically added to the project.

Resolves https://github.com/tabvengers/spicy-sections/issues/42