### PR TITLE
add support for spicy-h

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -99,7 +99,7 @@ class MediaAffordancesElement extends HTMLElement {
   };
 
   let getLabels = regionset => {
-    return [...regionset.children].filter(el => /^H\d$/.test(el.tagName));
+    return [...regionset.children].filter(el => (/^H\d$/.test(el.tagName) || ("SPICY-H" == el.tagName)));
   };
 
   let getContentEls = regionset => {
@@ -146,13 +146,16 @@ class MediaAffordancesElement extends HTMLElement {
           ::slotted([hidden]) {
             display: none;
           }
+          
+          ::slotted(spicy-h) { display: block; }
 
           ::slotted(h1),
           ::slotted(h2),
           ::slotted(h3),
           ::slotted(h4),
           ::slotted(h5),
-          ::slotted(h6) {
+          ::slotted(h6),
+          ::slotted(spicy-h){
              margin-right: 1rem;
           }
 
@@ -463,16 +466,25 @@ class MediaAffordancesElement extends HTMLElement {
         }
       }
       this.observeAffordanceChange((matching, all) => {
-        checkDefaults();
+        if (!this.__defaults) {
+          this.__defaults = {
+            onMatch: this.hasAttribute("defaults-on-match"),
+            defaultActive: getLabels(this).filter(l =>
+              l.hasAttribute("default-activate")
+            )
+          };
+        }
         this.affordanceState.current = this.getAttribute("affordance");
         this.__configure();
       });
+
       this.setActiveAffordance = (matching, all) => {
         checkDefaults();
         this.setAttribute("affordance", matching);
         this.affordanceState.current = matching;
         this.__configure();
       }
+
 
       this.attachShadow({ mode: "open" });
       this.shadowRoot.innerHTML = template;

--- a/test/general-h.tests.js
+++ b/test/general-h.tests.js
@@ -6,12 +6,12 @@ const verifyTab = utils.verifyTab;
 const verifySimpleCollapseHeading = utils.verifySimpleCollapseHeading;
 const verifyExclusiveCollapseHeading = utils.verifyExclusiveCollapseHeading;
 
-fixture`Spicy sections - general tests using headings`
-    .page`https://spicy-sections.glitch.me/automation-tests-1.html`;
+fixture`Spicy sections - general tests using spicy-h`
+    .page`https://spicy-sections.glitch.me/automation-tests-2.html`;
 
 const heading = Selector("h1");
 const spicySection = Selector("spicy-sections");
-const spicyHeadings = Selector("spicy-sections > h2")
+const spicyHeadings = Selector("spicy-sections > spicy-h")
 
 const BREAKPOINTS = {
     'collapse': 570,


### PR DESCRIPTION
This adds support for using a `<spicy-h>` for 'headings' that aren't really headings but more generic labels/would still add affordances per discussions in #40 

This also adds a brute force copy/paste mod of the tests to show that all of the same things otherwise continue to 'work' as expected.   Surely this can be reworked to avoid duplication, but most of the actual logic of the tests is already extracted into utils and there are considerably bigger fish to fry wrt to tests (like wiring up the CI/github and moving the test fixtures from the glitch to here) and I have finite time... so, for now, let's get this in and consider that a todo?