### PR TITLE
Swap `Event#keyCode` for `Event#key`

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -506,14 +506,14 @@ class MediaAffordancesElement extends HTMLElement {
             this.affordanceState.current === "tab-bar" ||
             this.affordanceState.current === "exclusive-collapse"
           ) {
-            if (evt.keyCode == 37 || evt.keyCode == 38) {
+            if (evt.key == 'ArrowLeft' || evt.key == 'ArrowUp') {
               labels[prev].affordanceState.activate();
               evt.preventDefault()
-            } else if (evt.keyCode == 39 || evt.keyCode == 40) {
+            } else if (evt.key == 'ArrowRight' || evt.key == 'ArrowDown') {
               labels[next].affordanceState.activate();
               evt.preventDefault()
             }
-          } else if (evt.keyCode == 32 && this.affordanceState.current === 'collapse') {
+          } else if (evt.key == ' ' && this.affordanceState.current === 'collapse') {
             evt.preventDefault()
           }
         },
@@ -522,7 +522,7 @@ class MediaAffordancesElement extends HTMLElement {
       this.addEventListener(
         "keyup", 
         evt => {
-          if (evt.keyCode == 32 && this.affordanceState.current === 'collapse') {
+          if (evt.key == ' ' && this.affordanceState.current === 'collapse') {
             evt.target.closest('[affordance]').affordanceState.activate()
             evt.preventDefault()
           }


### PR DESCRIPTION
This change replaces the use of `KeyboardEvent#keyCode` [<sup>ref</sup>](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) with `KeyboardEvent#key` [<sup>ref</sup>](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).

The primary rationale is that `keyCode` is deprecated. I also think `KeyboardEvent#key` is a clearer interface, since it provides a printable representation of the key.

Browser support for `key` is 98.06% [<sup>2</sup>](https://caniuse.com/keyboardevent-key), and for context support for Custom Elements v1 is 95.84% [<sup>3</sup>](https://caniuse.com/custom-elementsv1).