### PR TITLE
Call `notifyChange()` less

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -57,18 +57,6 @@ class MediaAffordancesElement extends HTMLElement {
     if (newValue.trim().length === 0) {
       return;
     }
-    const debounce = (fn, delay) => {
-      let timeOutId;
-      return () => {
-        if(timeOutId) {
-          clearTimeout(timeOutId);
-        }
-        timeOutId = setTimeout(() => {
-          fn.call(this);
-        },delay);
-      }
-    }
-    let fn = debounce(this.notifyChange, 10)
     newValue.split("|").forEach(segment => {
       let mq = segment.trim().match(/\[([^\]]*)/)[1];
       let names = segment
@@ -77,12 +65,10 @@ class MediaAffordancesElement extends HTMLElement {
         .split(" ");
       let mql = window.matchMedia(mq);
       mql.__affordance = names[0] // one for now
-      mql.addEventListener("change", () => {
-       fn() 
-      });
-      fn()
+      mql.onchange = () => this.notifyChange();
       this.mqls.push(mql);
     }, this);
+    this.notifyChange();
   }
 
   attributeChangedCallback(name, oldValue, newValue) {


### PR DESCRIPTION
This changes the `notifyChange()` method to fire once at the end of `connectListeners()` [<sup>ref</sup>](https://github.com/tabvengers/spicy-sections/pull/58/files#diff-b8fa2e39de5a0752371453f870a51b123769285734098425b707702bbbee99acR71), removing the need for the additional debounce implementation [<sup>ref</sup>](https://github.com/tabvengers/spicy-sections/pull/58/files#diff-b8fa2e39de5a0752371453f870a51b123769285734098425b707702bbbee99acL60-L71).

**Implementation Detail:**
- `MediaQueryList#onchange` [<sup>ref</sup>](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/onchange) is used to preserve the `this` argument passed into `notifyChange()` [<sup>ref</sup>](https://github.com/tabvengers/spicy-sections/pull/58/files#diff-b8fa2e39de5a0752371453f870a51b123769285734098425b707702bbbee99acL80-R68).