### PR TITLE
Change testcafe to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Hidde de Vries"
   ],
   "license": "W3C",
-  "dependencies": {
+  "devDependencies": {
     "testcafe": "^1.17.0"
   }
 }


### PR DESCRIPTION
This moves `testcafe` from `dependencies` to `devDependencies`, since it is for development and not required to use this element.