### PR TITLE
Proposing a `toggle` event 

### DIFF
--- a/src/SpicySections.js
+++ b/src/SpicySections.js
@@ -278,6 +278,9 @@ class MediaAffordancesElement extends HTMLElement {
 						activate: () => {
 							if (this.affordanceState.current) {
 								this.__affordanceConf[this.affordanceState.current].toggle(labelEl)
+								// Dispatch a toggle event from the clicked 
+								const ToggleEvent = new CustomEvent('toggle', { bubbles: true, composed: true, cancelable: false });
+								labelEl.dispatchEvent(ToggleEvent);
 							}
 						},
 					}


### PR DESCRIPTION
This is a suggestion of a toggle event for `spicy-sections` that would actually be dispatched by the triggering label element and would bubble.

This would allow for listening for toggled changes from the user without having to add listeners for clicks and keyup/down events. This proposal is due to the fact i'm trying to apply transitions/animations and I need to have an in between state when hiding a section.

I know this isn't very detailed, but i hope to have a real world example in a couple of days.